### PR TITLE
Update AdminApiInterface.php

### DIFF
--- a/src/Admin/AdminApiInterface.php
+++ b/src/Admin/AdminApiInterface.php
@@ -373,7 +373,7 @@ interface AdminApiInterface extends ApiInterface
      * @return Message\CheckDomainMXRecordResponse
      */
     function checkDomainMXRecord(
-        DomainSelector $domain = null
+        ?DomainSelector $domain = null
     ): ?Message\CheckDomainMXRecordResponse;
 
     /**


### PR DESCRIPTION
 PHP Deprecated:  Zimbra\Admin\AdminApiInterface::checkDomainMXRecord(): Implicitly marking parameter $domain as nullable is deprecated